### PR TITLE
READMEをNuxtデフォルトからプロジェクト用に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,47 @@
-# openspending-frontend
+# Where Does My Money GO? フロントエンド
+## 概要
+あなたが払った税金が1日あたりどう使われているかを知ることで、
+公共サービスの受益と負担の関係を読み解く市民主導のプロジェクトです。
+こちらはフロントエンドのリポジトリです。
 
-## Build Setup
+## デモ
+ - [現行版サイト](https://tsukubashi.spending.jp/)
 
+## 環境
+ - Node.js ver.16
+ - NuxtJS ver.2
+ - TypeScript
+ - Yarn
+
+## 開発手順
+### 環境セットアップ
 ```bash
-# install dependencies
+# リポジトリをクローン
+$ git clone https://github.com/spendingjp/openspending-frontend.git
+$ cd openspending-frontend
+
+# 依存関係モジュールをインストール
 $ yarn install
-
-# serve with hot reload at localhost:3000
-$ yarn dev
-
-# build for production and launch server
-$ yarn build
-$ yarn start
-
-# generate static project
-$ yarn generate
 ```
 
-For detailed explanation on how things work, check out the [documentation](https://nuxtjs.org).
+### デバッグ実行
+```bash
+# 開発用サーバーを起動（ホットリロード有効）
+$ yarn dev
+```
 
-## Special Directories
+以下のURLを開いて、サイトが表示されれば成功です。
+ - [http://localhost:3000](http://localhost:3000)
 
-You can create the following extra directories, some of which have special behaviors. Only `pages` is required; you can delete them if you don't want to use their functionality.
+### 開発に参加するには
+Code for JapanのSlackに開発メンバー用チャンネルがあります。[Slackへの参加はこちらから](https://join.slack.com/t/cfj/shared_invite/zt-w2soa7jo-ZhVLNk5HjBMYm1GD72i36g)どうぞ。
+ - #proj-wdmmg       （プロジェクト全体）
+ - #proj-wdmmg-dev   （開発）
 
-### `assets`
+## 参考サイト
+ - 現行版
+   - [プロジェクトサイト](https://spending.jp/)
+   - [つくば市現行サイト](https://tsukubashi.spending.jp/)
 
-The assets directory contains your uncompiled assets such as Stylus or Sass files, images, or fonts.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/assets).
-
-### `components`
-
-The components directory contains your Vue.js components. Components make up the different parts of your page and can be reused and imported into your pages, layouts and even other components.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/components).
-
-### `layouts`
-
-Layouts are a great help when you want to change the look and feel of your Nuxt app, whether you want to include a sidebar or have distinct layouts for mobile and desktop.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/layouts).
-
-
-### `pages`
-
-This directory contains your application views and routes. Nuxt will read all the `*.vue` files inside this directory and setup Vue Router automatically.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/get-started/routing).
-
-### `plugins`
-
-The plugins directory contains JavaScript plugins that you want to run before instantiating the root Vue.js Application. This is the place to add Vue plugins and to inject functions or constants. Every time you need to use `Vue.use()`, you should create a file in `plugins/` and add its path to plugins in `nuxt.config.js`.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/plugins).
-
-### `static`
-
-This directory contains your static files. Each file inside this directory is mapped to `/`.
-
-Example: `/static/robots.txt` is mapped as `/robots.txt`.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/static).
-
-### `store`
-
-This directory contains your Vuex store files. Creating a file in this directory automatically activates Vuex.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/store).
+ - 開発中
+   - [バックエンド リポジトリ（GitHub）](https://github.com/spendingjp/openspending-backend)


### PR DESCRIPTION
README.mdをプロジェクト用に変更しました。
開発を始めるために必要なコマンドや、参考情報を記載しています。