### PR TITLE
固定ページのデザインおよびマークアップ調整

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -8,19 +8,3 @@ body {
     'Hiragino Sans', 'BIZ UDPGothic', Meiryo, sans-serif;
   line-height: 1.9;
 }
-
-h3 {
-  border-bottom: solid 3px $light;
-  position: relative;
-  color: $info;
-  font-weight: bold;
-}
-
-h3:after {
-  position: absolute;
-  content: ' ';
-  display: block;
-  border-bottom: solid 3px $primary;
-  bottom: -3px;
-  width: 30%;
-}

--- a/components/ContentsBlock.vue
+++ b/components/ContentsBlock.vue
@@ -25,9 +25,20 @@ export default Vue.extend({
   margin-bottom: 50px;
 }
 .content-title {
+  position: relative;
+  color: $info;
   margin: 16px 0;
   padding-bottom: 10px;
-  border-bottom: 1px solid $primary;
+  border-bottom: solid 3px $light;
+
+  &::after {
+    position: absolute;
+    content: ' ';
+    display: block;
+    border-bottom: solid 3px $primary;
+    bottom: -3px;
+    width: 30%;
+  }
 }
 .content-container {
   margin-left: 5em;

--- a/components/PageTitle.vue
+++ b/components/PageTitle.vue
@@ -1,5 +1,5 @@
 <template>
-  <h1 class="page-title fs-5">{{ title }}</h1>
+  <h1 class="page-title fs-3">{{ title }}</h1>
 </template>
 
 <script lang="ts">

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,48 +1,33 @@
 <template>
-  <div class="container mt-3">
-    <div class="row">
-      <div class="col">
-        <h3>Forum</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center">
-      <div class="col-lg-7">
-        <p>
-          Slackに開発者用のチャンネルがありますので、開発に関する質問やディスカッションはこちらでお願いします。<br />
-          <a
-            href="https://cfjslackin.herokuapp.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            >Code for Japan の Slack ワークスペース</a
-          >の、#proj-wdmmg-dev
-        </p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">
-        <h3>Contact</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center">
-      <div class="col-lg-7">
-        <iframe
-          id="contact-form"
-          src="https://docs.google.com/a/georepublic.de/spreadsheet/embeddedform?formkey=dGw3ZTNvYjRkRnFWb3JDUDJuNExpWFE6MQ"
-          frameborder="0"
-          marginheight="0"
-          marginwidth="0"
-          >Loading...</iframe
-        >
-      </div>
-    </div>
+  <div class="container mb-4 mt-3">
+    <page-title title="お問い合わせ" />
+    <contents-block title="Forum">
+      <p>
+        Slackに開発者用のチャンネルがありますので、開発に関する質問やディスカッションはこちらでお願いします。<br />
+        <a
+          href="https://cfjslackin.herokuapp.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >Code for Japan の Slack ワークスペース</a
+        >の、#proj-wdmmg-dev
+      </p>
+    </contents-block>
+    <contents-block title="Contact">
+      <iframe
+        class="contact-form"
+        src="https://docs.google.com/a/georepublic.de/spreadsheet/embeddedform?formkey=dGw3ZTNvYjRkRnFWb3JDUDJuNExpWFE6MQ"
+      >Loading...</iframe>
+    </contents-block>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
+import PageTitle from '@/components/PageTitle.vue'
+import ContentsBlock from '@/components/ContentsBlock.vue'
 
 export default Vue.extend({
+  components: { PageTitle, ContentsBlock },
   head() {
     return {
       title: 'お問い合わせ',
@@ -51,8 +36,8 @@ export default Vue.extend({
 })
 </script>
 
-<style lang="scss">
-#contact-form {
+<style lang="scss" scoped>
+.contact-form {
   width: 100%;
   height: 500px;
 }

--- a/pages/links.vue
+++ b/pages/links.vue
@@ -1,56 +1,45 @@
 <template>
-  <div class="container mt-3">
-    <div class="row">
-      <div class="col">
-        <h3>提供地域</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center">
-      <div class="col-lg-7">
-        <p>
-          Where Does My Money Go?
-          は、今後、各地の有志の手により多くの地域でも提供されることが期待されています。
-          自分の街のバージョンを立ち上げたい方や、他の地域でのクローンサイトがあるか確かめたい方は、プロジェクトサイト(<a
-            href="https://openspending.net/"
-            target="_blank"
-            rel="noopener noreferrer"
-            >https://openspending.net/</a
-          >)へアクセスしてみてください。 このサイトのソースコードは、<a
-            href="http://opendefinition.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-            >Open Definition</a
-          >の定義に沿っていれば、どなたでも利用、改変、及び再配布が可能です。
-          上記プロジェクトページに、このサイトをコピーして独自のサイトを作る為のドキュメントがありますので、是非ご自由にお使いください。
-          あなたのサイトを作成したら、是非御連絡いただければと思います。
-        </p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">
-        <h3>サポート</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center">
-      <div class="col-lg-7">
-        <p>
-          ご興味ある方は、<a
-            href="https://cfjslackin.herokuapp.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            >Code for Japan の Slack ワークスペース</a
-          >の、#proj-wdmmg チャンネルにご参加ください。
-        </p>
-      </div>
-    </div>
+  <div class="container mb-4 mt-3">
+    <page-title title="関連サイト" />
+    <contents-block title="提供地域">
+      <p>
+        Where Does My Money Go?
+        は、今後、各地の有志の手により多くの地域でも提供されることが期待されています。
+        自分の街のバージョンを立ち上げたい方や、他の地域でのクローンサイトがあるか確かめたい方は、プロジェクトサイト(<a
+        href="https://openspending.net/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >https://openspending.net/</a
+      >)へアクセスしてみてください。 このサイトのソースコードは、<a
+        href="http://opendefinition.org/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Open Definition</a
+      >の定義に沿っていれば、どなたでも利用、改変、及び再配布が可能です。
+        上記プロジェクトページに、このサイトをコピーして独自のサイトを作る為のドキュメントがありますので、是非ご自由にお使いください。
+        あなたのサイトを作成したら、是非御連絡いただければと思います。
+      </p>
+    </contents-block>
+    <contents-block title="サポート">
+      <p>
+        ご興味ある方は、<a
+        href="https://cfjslackin.herokuapp.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Code for Japan の Slack ワークスペース</a
+      >の、#proj-wdmmg チャンネルにご参加ください。
+      </p>
+    </contents-block>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
+import PageTitle from '@/components/PageTitle.vue'
+import ContentsBlock from '@/components/ContentsBlock.vue'
 
 export default Vue.extend({
+  components: { PageTitle, ContentsBlock },
   head() {
     return {
       title: '関連サイト',

--- a/pages/sources.vue
+++ b/pages/sources.vue
@@ -1,65 +1,47 @@
 <template>
-  <div class="container mt-3">
-    <div class="row">
-      <div class="col">
-        <h3>データの出所</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center mb-3">
-      <div class="col-lg-7">
-        <p>
-          このサイトは、{{ budgetName }}の事業名単位のデータを用いています。
-        </p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">
-        <h3>いつの時点のデータを使っているのか？</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center mb-3">
-      <div class="col-lg-7">
-        <p>{{ year }}年度当初予算のデータを使っています。</p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">
-        <h3>このサイト上で税金額はどのように計算されているのですか？</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center mb-3">
-      <div class="col-lg-7">
-        <p>
-          自分の年間総収入を入力し、単身世帯かそれ以外かを選択すると、給与所得者であるという前提で、年間に支払う年間総税額と一日当たりに支払っている税額が表示されます。一日当たりの税額は10分野に分類されています。また、１０の各分野毎に支払われている税額は、それぞれ、主要な事業予算を担当している税額に細分類されています。
-          <br />
-          所得控除額は、単身世帯の場合33万円、扶養一人世帯の場合66万円、税負担額は課税対象額の6％と設定しています。また、10分野への税金の配分比率は、つくば市の一般会計全体における10分野への予算配分比率({{
-            year
-          }}年度)を使っています。
-        </p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">
-        <h3>どのようなデータを使っているのですか？</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center mb-3">
-      <div class="col-lg-7">
-        <p>
-          今回のWhere Does My Money Go? は{{ region }}の{{
-            year
-          }}年度一般会計予算を対象としています。今後、各自治体や日本政府の一般会計、特別会計、公営企業会計へと対象を広げることも考えています。
-        </p>
-      </div>
-    </div>
+  <div class="container mb-4 mt-3">
+    <page-title title="データの出所" />
+    <contents-block title="データの出所">
+      <p>
+        このサイトは、{{ budgetName }}の事業名単位のデータを用いています。
+      </p>
+    </contents-block>
+    <contents-block title="どのように可視化に使っているデータの分類を決めているのですか？">
+      <p>
+        このサイトは、令和２年度の自治体の一般会計当初予算の事業名単位のデータをもとに、各事業が国連のClassification of Functions of Government (COFOG)の第２レイヤー分類のどこに紐づくかを一つ一つ判断して作成しています。
+      </p>
+    </contents-block>
+    <contents-block title="いつの時点のデータを使っているのですか？">
+      <p>{{ year }}年度当初予算のデータを使っています。</p>
+    </contents-block>
+    <contents-block title="このサイト上で税金額はどのように計算されているのですか？">
+      <p>
+        自分の年間総収入を入力し、単身世帯かそれ以外かを選択すると、給与所得者であるという前提で、年間に支払う年間総税額と一日当たりに支払っている税額が表示されます。一日当たりの税額は10分野に分類されています。また、１０の各分野毎に支払われている税額は、それぞれ、主要な事業予算を担当している税額に細分類されています。
+        <br />
+        所得控除額は、単身世帯の場合33万円、扶養一人世帯の場合66万円、税負担額は課税対象額の6％と設定しています。また、10分野への税金の配分比率は、つくば市の一般会計全体における10分野への予算配分比率({{
+          year
+        }}年度)を使っています。
+      </p>
+    </contents-block>
+    <contents-block title="どのようなデータを使っているのですか？">
+      <p>
+        今回のWhere Does My Money Go? は{{ region }}の{{
+          year
+        }}年度一般会計予算を対象としています。今後、各自治体や日本政府の一般会計、特別会計、公営企業会計へと対象を広げることも考えています。
+      </p>
+    </contents-block>
+    <contents-block title="私のデータの視覚化をお願いできますか？">
+      <p>
+        はい、できます。もし、視覚化したいデータをお持ちであれば、COFOGフォーマットに紐付けしたデータセット（Excel）をお問合せにお送りください。
+      </p>
+    </contents-block>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
+import PageTitle from '@/components/PageTitle.vue'
+import ContentsBlock from '@/components/ContentsBlock.vue'
 
 type DataType = {
   /**
@@ -77,6 +59,7 @@ type DataType = {
 }
 
 export default Vue.extend({
+  components: { PageTitle, ContentsBlock },
   data(): DataType {
     return {
       region: this.$accessor.regionCofogData.regionCofogData.governmentName,

--- a/pages/team.vue
+++ b/pages/team.vue
@@ -1,50 +1,47 @@
 <template>
-  <div class="container">
-    <div class="row">
-      <div class="col">
-        <h3>Core Team</h3>
-      </div>
-    </div>
-    <div class="row justify-content-center">
-      <div class="col-lg-7">
-        <ul>
-          <li>
-            川島 宏一(Hiroichi Kawashima),
-            <a
-              href="https://twitter.com/hiroichi_k"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              @hiroichi_k</a
-            >
-            (Coordinator)
-          </li>
-          <li>
-            関 治之(Hal Seki):<a
-              href="https://twitter.com/hal_sk"
-              target="_blank"
-              rel="noopener noreferrer"
-              >@hal_sk</a
-            >, (Developer)
-          </li>
-          <li>
-            おそけん:<a
-              href="https://twitter.com/oso_ken"
-              target="_blank"
-              rel="noopener noreferrer"
-              >@oso_ken</a
-            >, (Developer)
-          </li>
-        </ul>
-      </div>
-    </div>
+  <div class="container mb-4 mt-3">
+    <page-title title="開発者" />
+    <contents-block title="Core Team">
+      <ul>
+        <li>
+          川島 宏一(Hiroichi Kawashima),
+          <a
+            href="https://twitter.com/hiroichi_k"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            @hiroichi_k</a
+          >
+          (Coordinator)
+        </li>
+        <li>
+          関 治之(Hal Seki):<a
+          href="https://twitter.com/hal_sk"
+          target="_blank"
+          rel="noopener noreferrer"
+        >@hal_sk</a
+        >, (Developer)
+        </li>
+        <li>
+          おそけん:<a
+          href="https://twitter.com/oso_ken"
+          target="_blank"
+          rel="noopener noreferrer"
+        >@oso_ken</a
+        >, (Developer)
+        </li>
+      </ul>
+    </contents-block>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
+import PageTitle from '@/components/PageTitle.vue'
+import ContentsBlock from '@/components/ContentsBlock.vue'
 
 export default Vue.extend({
+  components: { PageTitle, ContentsBlock },
   head() {
     return {
       title: '開発者',


### PR DESCRIPTION
close #34 

- 固定ページのマークアップを修正しました。
  - h1タイトルを設定
  - 各ブロックの見出しはh2に
- スタイルはコンポーネントに集約しました。
- とりあえず一旦現行サイトのコンテンツを反映しています。
- 文章の口調を揃えました。
  - 「〜のか？」→「〜のですか？」

## 申し送り
- 可変テキスト（日付）の変数化は別途対応
- 文章の校正は別途対応
- 全体の幅が広すぎるかもしれないので、別途検討

![about](https://user-images.githubusercontent.com/14883063/155321429-e56e78d6-42d6-4edc-8342-17ec6abca591.png)
![source](https://user-images.githubusercontent.com/14883063/155321462-eb722d13-1708-4811-94d0-655da34421f2.png)
![team](https://user-images.githubusercontent.com/14883063/155321523-2e7ea470-0ed6-4e9d-9967-09a404c5807a.png)
![links](https://user-images.githubusercontent.com/14883063/155321547-1253d7df-9d6c-4927-b80e-b9630f488549.png)
![contact](https://user-images.githubusercontent.com/14883063/155321575-e5472cd8-95b0-4ae5-a826-859c9cb775e5.png)
