### PR TITLE
APIからカラーを取得

### DIFF
--- a/assets/css/_var.scss
+++ b/assets/css/_var.scss
@@ -1,5 +1,4 @@
-$primary:       #BF9D73;
-$secondary:     #4369D9;
 $light:         #359AF2;
 $dark:          #0F1640;
 $info:          #2E3C8C;
+$gray:          #FEFEFE;

--- a/components/ContentsBlock.vue
+++ b/components/ContentsBlock.vue
@@ -26,16 +26,16 @@ export default Vue.extend({
 }
 .content-title {
   position: relative;
-  color: $info;
+  color: $dark;
   margin: 16px 0;
   padding-bottom: 10px;
-  border-bottom: solid 3px $light;
+  border-bottom: solid 3px var(--secondary);
 
   &::after {
     position: absolute;
     content: ' ';
     display: block;
-    border-bottom: solid 3px $primary;
+    border-bottom: solid 3px var(--primary);
     bottom: -3px;
     width: 30%;
   }

--- a/components/DailyBread.vue
+++ b/components/DailyBread.vue
@@ -231,9 +231,9 @@ export default Vue.extend({
 }
 
 .title {
-  border-bottom: solid 3px $light;
+  border-bottom: solid 3px var(--secondary);
   position: relative;
-  color: $info;
+  color: $dark;
   font-size: 1.5rem;
   font-weight: bold;
   margin: 16px 0;
@@ -243,7 +243,7 @@ export default Vue.extend({
     position: absolute;
     content: ' ';
     display: block;
-    border-bottom: solid 3px $primary;
+    border-bottom: solid 3px var(--primary);
     bottom: -3px;
     width: 30%;
   }

--- a/components/PageTitle.vue
+++ b/components/PageTitle.vue
@@ -18,6 +18,7 @@ export default Vue.extend({
 <style scoped lang="scss">
 .page-title {
   position: relative;
+  color: $dark;
   margin: 20px 0 60px;
   padding-bottom: 10px;
 
@@ -25,7 +26,7 @@ export default Vue.extend({
     position: absolute;
     content: ' ';
     display: block;
-    border-bottom: 5px solid $primary;
+    border-bottom: 5px solid var(--primary);
     bottom: -3px;
     width: 50px;
   }

--- a/components/atoms/IconRadioButton.vue
+++ b/components/atoms/IconRadioButton.vue
@@ -36,16 +36,16 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 button {
-  border: 2px solid $primary;
-  border-bottom: 5px solid $primary;
+  border: 2px solid var(--primary);
+  border-bottom: 5px solid var(--primary);
   background-color: #fefefe;
   margin: 0 10px;
 }
 
 button.checked {
   margin-top: 3px;
-  border-bottom: 2px solid $primary;
-  color: $primary;
+  border-bottom: 2px solid var(--primary);
+  color: var(--primary);
 }
 
 button.unchecked {
@@ -56,8 +56,7 @@ button.unchecked {
 
 button:hover {
   margin-top: 3px;
-  border: 2px solid $primary;
-  border-bottom: 2px solid $primary;
+  border: 2px solid var(--primary);
 }
 
 .text {
@@ -65,7 +64,7 @@ button:hover {
 }
 
 .checked-text {
-  color: $primary;
+  color: var(--primary);
   font-weight: bold;
 }
 

--- a/components/atoms/slider.vue
+++ b/components/atoms/slider.vue
@@ -90,7 +90,7 @@ input[type='range'] {
 /* つまみ */
 input[type='range']::-webkit-slider-thumb {
   -webkit-appearance: none;
-  background: $primary;
+  background: var(--primary);
   width: 24px;
   height: 24px;
   background-size: cover;

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -70,11 +70,11 @@ export default Vue.extend({
 })
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 footer {
   margin-top: 50px;
   background-color: #0f1640;
-  color: #fefefe;
+  color: $gray;
 }
 
 .footer {

--- a/components/header.vue
+++ b/components/header.vue
@@ -94,7 +94,7 @@
           <div class="col-sm-7 col-12 text-sm-end text-start">
             <small
               >あなたが
-              <span class="text-primary">{{ region }}</span>
+              <span class="region">{{ region }}</span>
               に納めた税金がどこで使われているかをお示しします</small
             >
           </div>
@@ -117,11 +117,11 @@ export default Vue.extend({
 </script>
 <style lang='scss' scoped>
 .header {
-  background-color: $info;
+  background-color: var(--primary);
 }
 
 a.navbar-brand {
-  color: $primary;
+  color: $gray;
   font-weight: bold;
   font-size: 4.5vmin;
   @media (min-width: 640px) {
@@ -129,39 +129,37 @@ a.navbar-brand {
   }
 
   &:hover {
-    color: #fefefe;
+    color: $gray;
   }
 }
 
 .sub-title {
   background-color: $dark;
-  color: $dark;
   font-weight: bold;
-  padding: 3px 0;
-  border-bottom: $dark solid 3px;
+  padding: 5px 0;
 
   & div {
-    color: #fefefe;
+    color: $gray;
+  }
+
+  .region {
+    color: $light;
   }
 }
 
 #navbarSupportedContent a {
-  color: #f2f2f2;
+  color: $gray;
   font-weight: bold;
 }
 
 #navbarSupportedContent a.active {
-  color: #f2f2f2;
+  color: $dark;
   font-weight: bold;
-  border-bottom: $primary solid 2px;
+  border-bottom: $dark solid 2px;
   padding-bottom: 2px;
 }
 
-#navbarSupportedContent a.active:hover {
-  border: none;
-}
-
 #navbarSupportedContent a:hover {
-  color: $primary;
+  color: $dark;
 }
 </style>

--- a/components/molecules/IncomeSelector.vue
+++ b/components/molecules/IncomeSelector.vue
@@ -151,7 +151,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .money {
-  color: $primary;
+  color: var(--primary);
   font-size: 1.5em;
   font-weight: bold;
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -20,7 +20,7 @@ export default Vue.extend({
   mounted() {
     const primary = this.$store.state.regionCofogData.primaryColorCode ?? this.defaultPrimary
     const secondary = this.$store.state.regionCofogData.secondaryColorCode ?? this.defaultSecondary
-    document.documentElement.setAttribute('style', `--color-primary: ${primary}; --color-secondary: ${secondary};`);
+    document.documentElement.setAttribute('style', `--primary: ${primary}; --secondary: ${secondary};`);
   }
 })
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,7 +10,19 @@
 
 <script lang="ts">
 import Vue from 'vue'
-export default Vue.extend({})
+export default Vue.extend({
+  data() {
+    return {
+      defaultPrimary: '#BF9D73',
+      defaultSecondary: '#4369D9',
+    }
+  },
+  mounted() {
+    const primary = this.$store.state.regionCofogData.primaryColorCode ?? this.defaultPrimary
+    const secondary = this.$store.state.regionCofogData.secondaryColorCode ?? this.defaultSecondary
+    document.documentElement.setAttribute('style', `--color-primary: ${primary}; --color-secondary: ${secondary};`);
+  }
+})
 </script>
 
 <style>

--- a/plugins/api/COFOGAPIResponse.ts
+++ b/plugins/api/COFOGAPIResponse.ts
@@ -26,6 +26,8 @@ export interface COFOGAPIResponse {
     slug: string
     latitude: number
     longitude: number
+    primaryColorCode: string | null
+    secondaryColorCode: string | null
     createdAt: string
     updatedAt: string
   }

--- a/plugins/applicationServices/COFOGAPIService.ts
+++ b/plugins/applicationServices/COFOGAPIService.ts
@@ -52,6 +52,8 @@ export class COFOGAPIService {
         year: apiResponse.year,
         governmentName: apiResponse.government.name,
         budgetName: apiResponse.sourceBudget.name,
+        primaryColorCode: apiResponse.government.primaryColorCode,
+        secondaryColorCode: apiResponse.government.secondaryColorCode,
       }
     } catch (e) {
       throw new Error('APIレスポンスをオブジェクトに変換失敗')

--- a/plugins/dataTransferObjects/cofogData.ts
+++ b/plugins/dataTransferObjects/cofogData.ts
@@ -42,4 +42,9 @@ export type CofogData = Readonly<{
    * 予算名称
    */
   budgetName: string
+  /**
+   * カラーコード
+   */
+  primaryColorCode: string | null
+  secondaryColorCode: string | null
 }>

--- a/plugins/repositories/CofogDataRepository.ts
+++ b/plugins/repositories/CofogDataRepository.ts
@@ -22,6 +22,8 @@ export class CofogDataRepository {
       budgetName: storeData.budgetName,
       year: storeData.year,
       governmentName: storeData.governmentName,
+      primaryColorCode: storeData.primaryColorCode,
+      secondaryColorCode: storeData.secondaryColorCode,
       taxList: storeData.taxList.map((item: any) => {
         return {
           amount: Price.create(item.amount._value),

--- a/test/api/COFOGAPIService.spec.ts
+++ b/test/api/COFOGAPIService.spec.ts
@@ -33,6 +33,8 @@ describe('APIService', () => {
       year: 2021,
       governmentName: 'つくば市',
       budgetName: 'つくば市YYYY年度予算',
+      primaryColorCode: null,
+      secondaryColorCode: null,
       taxList: [
         {
           cofog: new Cofog(
@@ -89,6 +91,8 @@ describe('APIService', () => {
       year: 2021,
       governmentName: 'つくば市',
       budgetName: 'つくば市YYYY年度予算',
+      primaryColorCode: null,
+      secondaryColorCode: null,
       taxList: [
         {
           cofog: new Cofog(
@@ -217,6 +221,8 @@ const response: COFOGAPIResponse = {
     slug: 'tsukuba-shi',
     latitude: 36.0825081,
     longitude: 140.1107132,
+    primaryColorCode: null,
+    secondaryColorCode: null,
     createdAt: '2022-02-04T15:47:03.420321Z',
     updatedAt: '2022-02-04T15:47:03.425683Z',
   },
@@ -307,6 +313,8 @@ const responseMultiRecords: COFOGAPIResponse = {
     slug: 'tsukuba-shi',
     latitude: 36.0825081,
     longitude: 140.1107132,
+    primaryColorCode: null,
+    secondaryColorCode: null,
     createdAt: '2022-02-04T15:47:03.420321Z',
     updatedAt: '2022-02-04T15:47:03.425683Z',
   },

--- a/test/applicationServices/TaxApplicationService.spec.ts
+++ b/test/applicationServices/TaxApplicationService.spec.ts
@@ -77,6 +77,8 @@ const inputCofogData = {
   year: 2021,
   governmentName: 'つくば市',
   budgetName: 'つくば市YYYY年度予算',
+  primaryColorCode: null,
+  secondaryColorCode: null,
   taxList: [
     {
       amount: Price.create(8000),

--- a/test/domainServices/TaxService.spec.ts
+++ b/test/domainServices/TaxService.spec.ts
@@ -27,6 +27,8 @@ describe('TaxService', () => {
             year: 2021,
             governmentName: 'つくば市',
             budgetName: 'つくば市YYYY年度予算',
+            primaryColorCode: null,
+            secondaryColorCode: null,
             taxList: [
               {
                 amount: Price.create(8000),

--- a/test/repositories/CofogRepository.spec.ts
+++ b/test/repositories/CofogRepository.spec.ts
@@ -40,6 +40,8 @@ describe('CofogRepository', () => {
         slug: 'tsukuba-shi',
         latitude: 36.0825081,
         longitude: 140.1107132,
+        primaryColorCode: null,
+        secondaryColorCode: null,
         createdAt: '2022-02-04T15:47:03.420321Z',
         updatedAt: '2022-02-04T15:47:03.425683Z',
       },

--- a/test/store/CofogStore.spec.ts
+++ b/test/store/CofogStore.spec.ts
@@ -30,6 +30,8 @@ describe('CofogVuex', () => {
       year: 2021,
       governmentName: 'つくば市',
       budgetName: 'つくば市YYYY年度予算',
+      primaryColorCode: null,
+      secondaryColorCode: null,
       taxList: [
         {
           amount: Price.create(27738407000.0),
@@ -90,6 +92,8 @@ const response: COFOGAPIResponse = {
     slug: 'tsukuba-shi',
     latitude: 36.0825081,
     longitude: 140.1107132,
+    primaryColorCode: null,
+    secondaryColorCode: null,
     createdAt: '2022-02-04T15:47:03.420321Z',
     updatedAt: '2022-02-04T15:47:03.425683Z',
   },


### PR DESCRIPTION
close #47 

APIから取得したカラーコードをstoreに保存し、デフォルトlayoutでcss variablesにセットしています。
（もっと効率のいいやり方があるかもしれないのですが、ちょっと思いつかず...）

カラーを調整した結果が以下です。文字色と背景色の関係が難しいですね。

![使途一日あたり-税金はどこへ行った？ (2)](https://user-images.githubusercontent.com/14883063/155845919-294c9352-aaa5-491a-b21f-91736d1c4368.png)
