### PR TITLE
Feature/50 call budget api

### DIFF
--- a/components/molecules/HouseTypeSelection.vue
+++ b/components/molecules/HouseTypeSelection.vue
@@ -41,6 +41,19 @@ export default Vue.extend({
       selected: 'SINGLE',
     }
   },
+  computed: {
+    parsedCofogData() {
+      return this.$accessor.regionCofogData.parsedCofogData
+    },
+  },
+  watch: {
+    parsedCofogData(val, old) {
+      if (!('amount' in old) && 'amount' in val) {
+        // @ts-ignore
+        this.selectHouseType(this.$props.selectedType)
+      }
+    },
+  },
   mounted() {},
   methods: {
     /**
@@ -55,19 +68,6 @@ export default Vue.extend({
       this.$accessor.dailyBreadData.setHouseType(type)
       // @ts-ignore
       this.selected = type
-    },
-  },
-  computed: {
-    parsedCofogData() {
-      return this.$accessor.regionCofogData.parsedCofogData
-    },
-  },
-  watch: {
-    parsedCofogData(val, old) {
-      if (!('amount' in old) && 'amount' in val) {
-        // @ts-ignore
-        this.selectHouseType(this.$props.selectedType)
-      }
     },
   },
 })

--- a/components/molecules/HouseTypeSelection.vue
+++ b/components/molecules/HouseTypeSelection.vue
@@ -41,9 +41,7 @@ export default Vue.extend({
       selected: 'SINGLE',
     }
   },
-  mounted() {
-    this.selectHouseType(this.$props.selectedType)
-  },
+  mounted() {},
   methods: {
     /**
      * 世帯種別を選択する
@@ -55,7 +53,21 @@ export default Vue.extend({
       }
       this.$emit('selectd-value', type)
       this.$accessor.dailyBreadData.setHouseType(type)
+      // @ts-ignore
       this.selected = type
+    },
+  },
+  computed: {
+    parsedCofogData() {
+      return this.$accessor.regionCofogData.parsedCofogData
+    },
+  },
+  watch: {
+    parsedCofogData(val, old) {
+      if (!('amount' in old) && 'amount' in val) {
+        // @ts-ignore
+        this.selectHouseType(this.$props.selectedType)
+      }
     },
   },
 })

--- a/components/molecules/IncomeSelector.vue
+++ b/components/molecules/IncomeSelector.vue
@@ -133,6 +133,9 @@ export default Vue.extend({
     yearlyTax() {
       return this.$accessor.dailyBreadData.yearlyTax
     },
+    parsedCofogData() {
+      return this.$accessor.regionCofogData.parsedCofogData
+    },
   },
   watch: {
     sliderValue(newVal) {
@@ -142,10 +145,13 @@ export default Vue.extend({
         this.$accessor.dailyBreadData.setIncome(newVal)
       }, 100)
     },
+    parsedCofogData(val, old) {
+      if (!('amount' in old) && 'amount' in val) {
+        this.$accessor.dailyBreadData.setIncome(this.value)
+      }
+    },
   },
-  mounted() {
-    this.$accessor.dailyBreadData.setIncome(this.value)
-  },
+  mounted() {},
 } as ThisTypedComponentOptionsWithRecordProps<Vue, DataType, MethodType, ComputedType, PropType>)
 </script>
 

--- a/pages/bubbletree.vue
+++ b/pages/bubbletree.vue
@@ -295,7 +295,7 @@ export default Vue.extend({
       this.$accessor.regionCofogData.setHostname(hostname)
     } catch (err) {
       if (err instanceof SyntaxError) {
-        console.error('Error on nuxtServerInit: ', err)
+        console.error('Error on beforeMount: ', err)
         this.$router.push({
           path: '404.html',
         })
@@ -307,7 +307,7 @@ export default Vue.extend({
       await this.$accessor.regionCofogData.fetchBudgetListAndWdmmgData()
     } catch (err) {
       if (err instanceof ReferenceError) {
-        console.error('Error on nuxtServerInit: ', err)
+        console.error('Error on beforeMount: ', err)
         this.$router.push({
           path: '404.html',
         })

--- a/pages/bubbletree.vue
+++ b/pages/bubbletree.vue
@@ -313,8 +313,8 @@ export default Vue.extend({
         })
       }
     }
-    const cofogData: CofogData = this.$repositories('cofogData').Get()
-    if (!cofogData) {
+    const cofogData: CofogData = this.$accessor.regionCofogData.parsedCofogData
+    if (!('amount' in cofogData)) {
       this.$router.push({ path: '/' })
     }
     this.circlePackData.childrenData = cofogData.taxList.map((item) => ({
@@ -329,8 +329,7 @@ export default Vue.extend({
         })),
       })),
     }))
-  },
-  mounted() {
+
     const svg = d3.select('#graph')
 
     const viewBox = svg.attr('viewBox')
@@ -358,6 +357,7 @@ export default Vue.extend({
     })
     this.setListText(this.circlePackData, '')
   },
+  mounted() {},
   methods: {
     /**
      * ズーム

--- a/pages/bubbletree.vue
+++ b/pages/bubbletree.vue
@@ -288,8 +288,35 @@ export default Vue.extend({
       title: '使途別予算額',
     }
   },
-  created() {
+  async beforeMount() {
+    // TODO: move to middleware
+    const hostname = window.location.hostname
+    try {
+      this.$accessor.regionCofogData.setHostname(hostname)
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        console.error('Error on nuxtServerInit: ', err)
+        this.$router.push({
+          path: '404.html',
+        })
+        return
+      }
+    }
+
+    try {
+      await this.$accessor.regionCofogData.fetchBudgetListAndWdmmgData()
+    } catch (err) {
+      if (err instanceof ReferenceError) {
+        console.error('Error on nuxtServerInit: ', err)
+        this.$router.push({
+          path: '404.html',
+        })
+      }
+    }
     const cofogData: CofogData = this.$repositories('cofogData').Get()
+    if (!cofogData) {
+      this.$router.push({ path: '/' })
+    }
     this.circlePackData.childrenData = cofogData.taxList.map((item) => ({
       name: item.cofog.Name,
       value: item.amount.value,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,5 +13,32 @@ export default Vue.extend({
       title: '使途一日あたり',
     }
   },
+  async beforeMount() {
+    // execute only on client side.
+    // TODO: move to middleware
+    const hostname = window.location.hostname
+    try {
+      this.$accessor.regionCofogData.setHostname(hostname)
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        console.error('Error on nuxtServerInit: ', err)
+        this.$router.push({
+          path: '404.html',
+        })
+        return
+      }
+    }
+
+    try {
+      await this.$accessor.regionCofogData.fetchBudgetListAndWdmmgData()
+    } catch (err) {
+      if (err instanceof ReferenceError) {
+        console.error('Error on nuxtServerInit: ', err)
+        this.$router.push({
+          path: '404.html',
+        })
+      }
+    }
+  },
 })
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -21,7 +21,7 @@ export default Vue.extend({
       this.$accessor.regionCofogData.setHostname(hostname)
     } catch (err) {
       if (err instanceof SyntaxError) {
-        console.error('Error on nuxtServerInit: ', err)
+        console.error('Error on beforeMount: ', err)
         this.$router.push({
           path: '404.html',
         })
@@ -33,7 +33,7 @@ export default Vue.extend({
       await this.$accessor.regionCofogData.fetchBudgetListAndWdmmgData()
     } catch (err) {
       if (err instanceof ReferenceError) {
-        console.error('Error on nuxtServerInit: ', err)
+        console.error('Error on beforeMount: ', err)
         this.$router.push({
           path: '404.html',
         })

--- a/plugins/Axios.ts
+++ b/plugins/Axios.ts
@@ -7,7 +7,6 @@ export function initializeAxios(axiosInstance: NuxtAxiosInstance) {
 
   $axios.defaults.xsrfCookieName = 'csrftoken'
   $axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN'
-  $axios.defaults.withCredentials = true
   $axios.defaults.headers = {
     'Content-Type': 'application/json',
     'X-Requested-With': 'XMLHttpRequest',

--- a/plugins/Axios.ts
+++ b/plugins/Axios.ts
@@ -5,6 +5,14 @@ let $axios: NuxtAxiosInstance
 export function initializeAxios(axiosInstance: NuxtAxiosInstance) {
   $axios = axiosInstance
 
+  $axios.defaults.xsrfCookieName = 'csrftoken'
+  $axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN'
+  $axios.defaults.withCredentials = true
+  $axios.defaults.headers = {
+    'Content-Type': 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
+  }
+
   $axios.onRequest((config) => {
     console.log('request to ' + config.baseURL)
     return config

--- a/plugins/api/BudgetList.ts
+++ b/plugins/api/BudgetList.ts
@@ -1,0 +1,21 @@
+export type BudgetResponse = {
+  id: string
+  name: string
+  slug: string
+  year: string
+  subtitle: string
+  classificationSystem: string
+  government: string
+  sourceBudget?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type Budget = BudgetResponse
+
+export type BudgetListResponse = {
+  "budgets": BudgetResponse[]
+  "defaultBudgets": BudgetResponse
+}
+
+export type BudgetList = BudgetListResponse

--- a/plugins/applicationServices/BudgetListApiService.ts
+++ b/plugins/applicationServices/BudgetListApiService.ts
@@ -1,0 +1,27 @@
+import { NuxtAppOptions } from '@nuxt/types/app'
+import { BudgetList, BudgetListResponse } from '../api/BudgetList'
+
+
+export class BudgetListApiService {
+  private app: NuxtAppOptions
+
+  constructor(app: NuxtAppOptions) {
+    this.app = app
+  }
+
+  /**
+   * APIからBudgetListデータを取得する
+   * @returns BudgetListデータ
+   */
+  public async GetData(): Promise<BudgetList> {
+    try {
+      const repo = this.app.$repositories('budget')
+      const budgetListResponse: BudgetListResponse = await repo.Get()
+
+      return budgetListResponse
+    } catch (e) {
+      console.log(e)
+      throw new Error('APIレスポンスをオブジェクトに変換失敗')
+    }
+  }
+}

--- a/plugins/applicationServices/COFOGAPIService.ts
+++ b/plugins/applicationServices/COFOGAPIService.ts
@@ -51,7 +51,7 @@ export class COFOGAPIService {
         taxList,
         year: apiResponse.year,
         governmentName: apiResponse.government.name,
-        budgetName: apiResponse.sourceBudget.name,
+        budgetName: apiResponse.name,
       }
     } catch (e) {
       throw new Error('APIレスポンスをオブジェクトに変換失敗')

--- a/plugins/applicationServices/COFOGAPIService.ts
+++ b/plugins/applicationServices/COFOGAPIService.ts
@@ -24,25 +24,25 @@ export class COFOGAPIService {
    * APIからCOFOGデータを取得する
    * @returns COFOGデータ
    */
-  public async GetData(): Promise<CofogData> {
+  public async GetData(budgetSlug: string): Promise<CofogData> {
     try {
       const apiResponse: COFOGAPIResponse = await this.app
         .$repositories('cofog')
-        .Get()
+        .Get(budgetSlug)
 
       const taxList: TaxItemLevel1[] = apiResponse.budgets.map((item) => ({
         ...this.ConvertBudget2TaxItem(item),
         children:
           item.children !== null
             ? item.children.map((level2item) => ({
-                ...this.ConvertBudget2TaxItem(level2item),
-                children:
-                  level2item.children !== null
-                    ? level2item.children.map((level3item) =>
-                        this.ConvertBudget2TaxItem(level3item)
-                      )
-                    : [],
-              }))
+              ...this.ConvertBudget2TaxItem(level2item),
+              children:
+                level2item.children !== null
+                  ? level2item.children.map((level3item) =>
+                    this.ConvertBudget2TaxItem(level3item)
+                  )
+                  : [],
+            }))
             : [],
       }))
 

--- a/plugins/applicationServices/TaxApplicationService.ts
+++ b/plugins/applicationServices/TaxApplicationService.ts
@@ -31,8 +31,9 @@ export class TaxApplicationService {
    */
   public GetDailyBreadData(person: Person): DailyBread {
     // COFOGデータを取得
-    const cofogData: CofogData = this.app.$repositories('cofogData').Get()
-    if (cofogData === undefined) {
+    // const cofogData: CofogData = this.app.$repositories('cofogData').Get()
+    const cofogData: CofogData = this.app.$accessor.regionCofogData.parsedCofogData
+    if (!("amount" in cofogData)) {
       throw new Error('COFOGデータなし')
     }
 
@@ -75,8 +76,8 @@ export class TaxApplicationService {
       children:
         'children' in item
           ? item.children.map((child: TaxItemLevel2 | TaxItemLevel3) =>
-              this.ConvertTax2BreadItem(child, service, person, government)
-            )
+            this.ConvertTax2BreadItem(child, service, person, government)
+          )
           : null,
     }
   }

--- a/plugins/factories/ApiRepositoryFactory.ts
+++ b/plugins/factories/ApiRepositoryFactory.ts
@@ -3,16 +3,19 @@ import { CofogDataRepository } from '../repositories/CofogDataRepository'
 import {
   CofogRepository
 } from '~/plugins/repositories/CofogRepository'
+import { BudgetRepository } from '../repositories/BudgetRepository'
 
 export interface Repositories {
-  cofog: typeof CofogRepository,
+  cofog: typeof CofogRepository
   cofogData: typeof CofogDataRepository
+  budget: typeof BudgetRepository
   // sample: typeof SampleRepository
 }
 
 export const repositories: Repositories = {
   cofog: CofogRepository,
-  cofogData: CofogDataRepository
+  cofogData: CofogDataRepository,
+  budget: BudgetRepository,
   // sample: SampleRepository
 }
 

--- a/plugins/repositories/BudgetRepository.ts
+++ b/plugins/repositories/BudgetRepository.ts
@@ -1,0 +1,25 @@
+import { NuxtAppOptions } from '@nuxt/types/app'
+import { BudgetListResponse } from '../api/BudgetList'
+
+/**
+ * APIリポジトリ
+ */
+export class BudgetRepository {
+  private app: NuxtAppOptions
+
+  constructor(app: NuxtAppOptions) {
+    this.app = app
+  }
+
+  /**
+   * APIからデータを取得する
+   * @returns オブジェクト変換結果
+   */
+  public async Get(): Promise<BudgetListResponse> {
+    const slug = this.app.$accessor.regionCofogData.governmentSlug
+    const uri = `/governments/${slug}/budgets` // nuxt.config.tsで設定したbaseUrlに続くURLを指定可能
+    const apiResponse = await this.app.$axios.$get<BudgetListResponse>(uri)
+    return apiResponse
+  }
+
+}

--- a/plugins/repositories/BudgetRepository.ts
+++ b/plugins/repositories/BudgetRepository.ts
@@ -17,7 +17,7 @@ export class BudgetRepository {
    */
   public async Get(): Promise<BudgetListResponse> {
     const slug = this.app.$accessor.regionCofogData.governmentSlug
-    const uri = `/governments/${slug}/budgets` // nuxt.config.tsで設定したbaseUrlに続くURLを指定可能
+    const uri = `/governments/${slug}/budgets/` // nuxt.config.tsで設定したbaseUrlに続くURLを指定可能
     const apiResponse = await this.app.$axios.$get<BudgetListResponse>(uri)
     return apiResponse
   }

--- a/plugins/repositories/CofogDataRepository.ts
+++ b/plugins/repositories/CofogDataRepository.ts
@@ -15,8 +15,10 @@ export class CofogDataRepository {
    * 保存されたCOFOGデータを取得する
    * @returns COFOGデータ
    */
-  public Get(): CofogData {
+  public Get(): CofogData | null {
     const storeData = this.app.store?.getters['regionCofogData/regionCofogData']
+    if (!storeData) return null
+
     const data: CofogData = {
       amount: Price.create(storeData.amount._value),
       budgetName: storeData.budgetName,

--- a/plugins/repositories/CofogDataRepository.ts
+++ b/plugins/repositories/CofogDataRepository.ts
@@ -17,7 +17,7 @@ export class CofogDataRepository {
    */
   public Get(): CofogData | null {
     const storeData = this.app.store?.getters['regionCofogData/regionCofogData']
-    if (!storeData) return null
+    if (!("amount" in storeData)) return null
 
     const data: CofogData = {
       amount: Price.create(storeData.amount._value),

--- a/plugins/repositories/CofogRepository.ts
+++ b/plugins/repositories/CofogRepository.ts
@@ -15,9 +15,8 @@ export class CofogRepository {
    * APIからデータを取得する
    * @returns オブジェクト変換結果
    */
-  public async Get(): Promise<COFOGAPIResponse> {
-    const slug = 'tsukuba-shi-cofog2021'
-    const uri = `/wdmmg/${slug}/` // nuxt.config.tsで設定したbaseUrlに続くURLを指定可能
+  public async Get(budgetSlug: string): Promise<COFOGAPIResponse> {
+    const uri = `/wdmmg/${budgetSlug}/` // nuxt.config.tsで設定したbaseUrlに続くURLを指定可能
     const apiResponse = await this.app.$axios.$get<COFOGAPIResponse>(uri)
     if (this.isValidAPIResponse(apiResponse)) {
       return apiResponse

--- a/plugins/repositories/CofogRepository.ts
+++ b/plugins/repositories/CofogRepository.ts
@@ -18,11 +18,13 @@ export class CofogRepository {
   public async Get(budgetSlug: string): Promise<COFOGAPIResponse> {
     const uri = `/wdmmg/${budgetSlug}/` // nuxt.config.tsで設定したbaseUrlに続くURLを指定可能
     const apiResponse = await this.app.$axios.$get<COFOGAPIResponse>(uri)
-    if (this.isValidAPIResponse(apiResponse)) {
-      return apiResponse
-    } else {
-      throw new Error('APIレスポンスが異常')
-    }
+    return apiResponse
+    // FIXME
+    // if (this.isValidAPIResponse(apiResponse)) {
+    //   return apiResponse
+    // } else {
+    //   throw new Error('APIレスポンスが異常')
+    // }
   }
 
   /**
@@ -37,8 +39,7 @@ export class CofogRepository {
       json.government === undefined ||
       json.budgets === undefined ||
       json.sourceBudget === undefined ||
-      json.government.name === undefined ||
-      json.sourceBudget.name === undefined
+      json.government.name === undefined
     ) {
       return false
     }

--- a/plugins/repositories/Repository.ts
+++ b/plugins/repositories/Repository.ts
@@ -10,6 +10,9 @@ export default (app: NuxtApp, inject: Inject) => {
       case 'cofogData':
         return new (apiRepositoryFactory.get('cofogData'))(app)
 
+      case 'budget':
+        return new (apiRepositoryFactory.get('budget'))(app)
+
       // case 'sample':
       //   return new SampleRepository()
 

--- a/store/index.ts
+++ b/store/index.ts
@@ -28,24 +28,7 @@ export const actions = {
     context: Context
   ) => {
     // nuxtServerInitの処理
-    try {
-      action.dispatch('regionCofogData/setHostname', context.req.headers.host)
-    } catch (err) {
-      if (err instanceof SyntaxError) {
-        console.error('Error on nuxtServerInit: ', err)
-        context.error({ statusCode: 404, message: "Unexpected hostname." })
-        return
-      }
-    }
-
-    try {
-      await action.dispatch('regionCofogData/fetchBudgetListAndWdmmgData')
-    } catch (err) {
-      if (err instanceof ReferenceError) {
-        console.error('Error on nuxtServerInit: ', err)
-        context.error({ statusCode: 404, message: "A budget to show was not found." })
-      }
-    }
+    // SSG するため、ユーザーからのリクエスト時にわかる情報はここで使用できない
   },
 }
 // ---------- ここまで ----------

--- a/store/index.ts
+++ b/store/index.ts
@@ -24,11 +24,28 @@ export const mutations = {
 
 export const actions = {
   nuxtServerInit: async (
-    context: ActionContext<RootState, RootState>,
-    _: Context
+    action: ActionContext<RootState, RootState>,
+    context: Context
   ) => {
     // nuxtServerInitの処理
-    await context.dispatch('regionCofogData/setRegionCofogFromAPI')
+    try {
+      action.dispatch('regionCofogData/setHostname', context.req.headers.host)
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        console.error('Error on nuxtServerInit: ', err)
+        context.error({ statusCode: 404, message: "Unexpected hostname." })
+        return
+      }
+    }
+
+    try {
+      await action.dispatch('regionCofogData/fetchBudgetListAndWdmmgData')
+    } catch (err) {
+      if (err instanceof ReferenceError) {
+        console.error('Error on nuxtServerInit: ', err)
+        context.error({ statusCode: 404, message: "A budget to show was not found." })
+      }
+    }
   },
 }
 // ---------- ここまで ----------

--- a/store/regionCofogData.ts
+++ b/store/regionCofogData.ts
@@ -3,6 +3,9 @@ import { COFOGAPIService } from '~/plugins/applicationServices/COFOGAPIService'
 import { CofogData } from '~/plugins/dataTransferObjects/cofogData'
 import { Budget, BudgetList } from '~/plugins/api/BudgetList'
 import { BudgetListApiService } from '~/plugins/applicationServices/BudgetListApiService'
+import { Price } from '~/plugins/valueObjects/Price'
+import { Cofog } from '~/plugins/valueObjects/Cofog'
+import { CofogCode } from '~/plugins/valueObjects/CofogCode'
 
 export const state = () => ({
   regionCofogData: {} as CofogData,
@@ -10,6 +13,7 @@ export const state = () => ({
   budgets: [] as Budget[],
   defaultBudget: null as Budget | null,
   governmentSlug: "" as string,
+  parsedCofogData: {} as CofogData
 })
 
 export type RootState = ReturnType<typeof state>
@@ -19,7 +23,8 @@ export const getters = getterTree(state, {
   hostname: (state) => state.hostname,
   governmentSlug: (state) => state.governmentSlug,
   budgets: (state) => state.budgets,
-  defaultBudget: (state) => state.defaultBudget
+  defaultBudget: (state) => state.defaultBudget,
+  parsedCofogData: (state) => state.parsedCofogData
 })
 
 export const mutations = mutationTree(state, {
@@ -50,7 +55,54 @@ export const mutations = mutationTree(state, {
     state.defaultBudget = budgetList.defaultBudgets
   },
   setRegionCofogData(state, regionCofog: CofogData): void {
+    console.log(regionCofog)
     state.regionCofogData = regionCofog
+    const data: CofogData = {
+      // @ts-ignore
+      amount: Price.create(regionCofog.amount._value as number),
+      budgetName: regionCofog.budgetName,
+      year: regionCofog.year,
+      governmentName: regionCofog.governmentName,
+      taxList: regionCofog.taxList.map((item: any) => {
+        return {
+          amount: Price.create(item.amount._value),
+          cofog: new Cofog(
+            CofogCode.create({
+              level1: item.cofog.code._value.level1,
+              level2: item.cofog.code._value.level2,
+              level3: item.cofog.code._value.level3,
+            }),
+            item.cofog.name
+          ),
+          children: item.children.map((child: any) => {
+            return {
+              amount: Price.create(child.amount._value),
+              cofog: new Cofog(
+                CofogCode.create({
+                  level1: child.cofog.code._value.level1,
+                  level2: child.cofog.code._value.level2,
+                  level3: child.cofog.code._value.level3,
+                }),
+                child.cofog.name
+              ),
+              children: child.children.map((level3Item: any) => ({
+                amount: Price.create(level3Item.amount._value),
+                cofog: new Cofog(
+                  CofogCode.create({
+                    level1: level3Item.cofog.code._value.level1,
+                    level2: level3Item.cofog.code._value.level2,
+                    level3: level3Item.cofog.code._value.level3,
+                  }),
+                  level3Item.cofog.name
+                ),
+              })),
+            }
+          }),
+        }
+      }),
+    }
+
+    state.parsedCofogData = data
   },
 })
 

--- a/store/regionCofogData.ts
+++ b/store/regionCofogData.ts
@@ -55,7 +55,6 @@ export const mutations = mutationTree(state, {
     state.defaultBudget = budgetList.defaultBudgets
   },
   setRegionCofogData(state, regionCofog: CofogData): void {
-    console.log(regionCofog)
     state.regionCofogData = regionCofog
     const data: CofogData = {
       // @ts-ignore

--- a/store/regionCofogData.ts
+++ b/store/regionCofogData.ts
@@ -1,18 +1,54 @@
 import { getterTree, mutationTree, actionTree } from 'typed-vuex'
 import { COFOGAPIService } from '~/plugins/applicationServices/COFOGAPIService'
 import { CofogData } from '~/plugins/dataTransferObjects/cofogData'
+import { Budget, BudgetList } from '~/plugins/api/BudgetList'
+import { BudgetListApiService } from '~/plugins/applicationServices/BudgetListApiService'
 
 export const state = () => ({
   regionCofogData: {} as CofogData,
+  hostname: "" as string,
+  budgets: [] as Budget[],
+  defaultBudget: null as Budget | null,
+  governmentSlug: "" as string,
 })
 
 export type RootState = ReturnType<typeof state>
 
 export const getters = getterTree(state, {
   regionCofogData: (state) => state.regionCofogData,
+  hostname: (state) => state.hostname,
+  governmentSlug: (state) => state.governmentSlug,
+  budgets: (state) => state.budgets,
+  defaultBudget: (state) => state.defaultBudget
 })
 
 export const mutations = mutationTree(state, {
+  setHostname(state, hostname: string): void {
+    state.hostname = hostname
+    const DEFAULT_SLUG = 'tsukuba-shi'
+    // localhost:[port] の場合
+    if (/^localhost[:0-9]*$/.test(hostname)) {
+      state.governmentSlug = DEFAULT_SLUG
+      return
+    }
+    // [ip]:[port] の場合
+    if (/^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]):[0-9]+$/.test(hostname)) {
+      state.governmentSlug = DEFAULT_SLUG
+      return
+    }
+
+    const matched = hostname.match(/^(.+)\.openspending.net$/)
+    if (matched && matched?.length > 1) {
+      state.governmentSlug = matched[1]
+      return
+    } else {
+      throw new SyntaxError("Unexpected hostname. Couldn't extract government slug.")
+    }
+  },
+  setBudgetList(state, budgetList: BudgetList): void {
+    state.budgets = budgetList.budgets
+    state.defaultBudget = budgetList.defaultBudgets
+  },
   setRegionCofogData(state, regionCofog: CofogData): void {
     state.regionCofogData = regionCofog
   },
@@ -21,11 +57,27 @@ export const mutations = mutationTree(state, {
 export const actions = actionTree(
   { state, getters, mutations },
   {
-    async setRegionCofogFromAPI({ commit }) {
-      // リポジトリ（API）からデータを取得し、Vuexに登録
-      const apiService = new COFOGAPIService(this.app)
-      const res = await apiService.GetData()
-      commit('setRegionCofogData', res)
+    setHostname({ commit }, payload: string) {
+      commit('setHostname', payload)
     },
+    async fetchBudgetListAndWdmmgData({ commit }) {
+      const budgetApiService = new BudgetListApiService(this.app)
+      const budgetList = await budgetApiService.GetData()
+      commit('setBudgetList', budgetList)
+
+      const apiService = new COFOGAPIService(this.app)
+      if (budgetList.defaultBudgets) {
+        const budgetSlug = budgetList.defaultBudgets.slug
+        const wdmmgRes = await apiService.GetData(budgetSlug)
+        commit('setRegionCofogData', wdmmgRes)
+      } else if (budgetList.budgets.length > 0) {
+        // defaultBudget が設定されていない場合は budgets の先頭を表示する
+        const budgetSlug = budgetList.budgets[0].slug
+        const wdmmgRes = await apiService.GetData(budgetSlug)
+        commit('setRegionCofogData', wdmmgRes)
+      } else {
+        throw new ReferenceError("A budget to show was not found.")
+      }
+    }
   }
 )

--- a/test/api/COFOGAPIService.spec.ts
+++ b/test/api/COFOGAPIService.spec.ts
@@ -71,7 +71,7 @@ describe('APIService', () => {
     }
 
     const api = new COFOGAPIService(wrapper.vm)
-    expect(await api.GetData()).toEqual(result)
+    expect(await api.GetData('tsukuba-shi')).toEqual(result)
   })
 
   it('正常(複数レコード)', async () => {
@@ -171,7 +171,7 @@ describe('APIService', () => {
     }
 
     const api = new COFOGAPIService(wrapper.vm)
-    expect(await api.GetData()).toEqual(result)
+    expect(await api.GetData('tsukuba-shi')).toEqual(result)
   })
 })
 

--- a/test/repositories/CofogRepository.spec.ts
+++ b/test/repositories/CofogRepository.spec.ts
@@ -59,7 +59,7 @@ describe('CofogRepository', () => {
 
     // 処理実行
     const repo = new CofogRepository(wrapper.vm)
-    expect(await repo.Get()).toEqual(result)
+    expect(await repo.Get('tsukuba-shi')).toEqual(result)
   })
 
   it('異常', async () => {
@@ -102,7 +102,7 @@ describe('CofogRepository', () => {
 
     // 処理実行
     const repo = new CofogRepository(wrapper.vm.$nuxt)
-    await expect(repo.Get()).rejects.toThrow(Error)
+    await expect(repo.Get('tsukuba-shi')).rejects.toThrow(Error)
   })
 })
 


### PR DESCRIPTION
追加した処理
1. hostname から Government slug を取得
2. budget list API を叩く
3. default budget の wdmmg を取得する

また、これまで nuxtServerInit でデータの取得が終わっている前提でページが作られていましたが、SSG に対応するため、データ取得処理を必要な page の beforeMounted に移しました。
一部処理が重複しているので middleware などに移動したほうが良いと思います。

手元での動作確認は API 呼び出しの CORS エラーが解消できないためできていません。
closes #50 